### PR TITLE
Add Hello Work and 404 pages

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,24 +1,10 @@
 import React from 'react';
-import logo from './logo.svg';
-import './App.css';
+import HelloWork from './HelloWork';
+import NotFound from './NotFound';
 
 function App() {
-  return (
-    <div className="App">
-      <header className="App-header">
-        <img src={logo} className="App-logo" alt="logo" />
-        <p>Bye there!</p>
-        <a
-          className="App-link"
-          href="https://reactjs.org"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Learn React
-        </a>
-      </header>
-    </div>
-  );
+  const path = window.location.pathname;
+  return path === '/' ? <HelloWork /> : <NotFound />;
 }
 
 export default App;

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -2,14 +2,14 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link!!!', () => {
+test('renders hello work on root path', () => {
+  window.history.pushState({}, '', '/');
   const { getByText } = render(<App />);
-  const linkElement = getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  expect(getByText(/hello work/i)).toBeInTheDocument();
 });
 
-test('renders learn react link!!!', () => {
+test('renders 404 page on unknown path', () => {
+  window.history.pushState({}, '', '/random');
   const { getByText } = render(<App />);
-  const linkElement = getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  expect(getByText(/404 - page not found/i)).toBeInTheDocument();
 });

--- a/src/HelloWork.js
+++ b/src/HelloWork.js
@@ -1,0 +1,7 @@
+import React from 'react';
+
+function HelloWork() {
+  return <h1>Hello Work</h1>;
+}
+
+export default HelloWork;

--- a/src/NotFound.js
+++ b/src/NotFound.js
@@ -1,0 +1,7 @@
+import React from 'react';
+
+function NotFound() {
+  return <h1>404 - Page Not Found</h1>;
+}
+
+export default NotFound;


### PR DESCRIPTION
## Summary
- add simple Hello Work page
- add 404 Not Found page
- update App to render page based on path
- add tests for Hello Work and 404 pages

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_b_68a56b66357c8331a5d2403f8a7e2db9